### PR TITLE
Color-coded page triangles and posts

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -11,8 +11,9 @@ const blog = defineCollection({
 		// Transform string to Date object
 		pubDate: z.coerce.date(),
 		updatedDate: z.coerce.date().optional(),
-		heroImage: image().optional(),
-	}),
+                heroImage: image().optional(),
+                color: z.enum(['red', 'blue', 'yellow']).optional(),
+        }),
 });
 
 export const collections = { blog };

--- a/src/content/blog/first-post.md
+++ b/src/content/blog/first-post.md
@@ -3,6 +3,7 @@ title: 'First post'
 description: 'Lorem ipsum dolor sit amet'
 pubDate: 'Jul 08 2022'
 heroImage: '../../assets/blog-placeholder-3.jpg'
+color: 'red'
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vitae ultricies leo integer malesuada nunc vel risus commodo viverra. Adipiscing enim eu turpis egestas pretium. Euismod elementum nisi quis eleifend quam adipiscing. In hac habitasse platea dictumst vestibulum. Sagittis purus sit amet volutpat. Netus et malesuada fames ac turpis egestas. Eget magna fermentum iaculis eu non diam phasellus vestibulum lorem. Varius sit amet mattis vulputate enim. Habitasse platea dictumst quisque sagittis. Integer quis auctor elit sed vulputate mi. Dictumst quisque sagittis purus sit amet.

--- a/src/content/blog/markdown-style-guide.md
+++ b/src/content/blog/markdown-style-guide.md
@@ -3,6 +3,7 @@ title: 'Markdown Style Guide'
 description: 'Here is a sample of some basic Markdown syntax that can be used when writing Markdown content in Astro.'
 pubDate: 'Jun 19 2024'
 heroImage: '../../assets/blog-placeholder-1.jpg'
+color: 'red'
 ---
 
 Here is a sample of some basic Markdown syntax that can be used when writing Markdown content in Astro.

--- a/src/content/blog/second-post.md
+++ b/src/content/blog/second-post.md
@@ -3,6 +3,7 @@ title: 'Second post'
 description: 'Lorem ipsum dolor sit amet'
 pubDate: 'Jul 15 2022'
 heroImage: '../../assets/blog-placeholder-4.jpg'
+color: 'blue'
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vitae ultricies leo integer malesuada nunc vel risus commodo viverra. Adipiscing enim eu turpis egestas pretium. Euismod elementum nisi quis eleifend quam adipiscing. In hac habitasse platea dictumst vestibulum. Sagittis purus sit amet volutpat. Netus et malesuada fames ac turpis egestas. Eget magna fermentum iaculis eu non diam phasellus vestibulum lorem. Varius sit amet mattis vulputate enim. Habitasse platea dictumst quisque sagittis. Integer quis auctor elit sed vulputate mi. Dictumst quisque sagittis purus sit amet.

--- a/src/content/blog/third-post.md
+++ b/src/content/blog/third-post.md
@@ -3,6 +3,7 @@ title: 'Third post'
 description: 'Lorem ipsum dolor sit amet'
 pubDate: 'Jul 22 2022'
 heroImage: '../../assets/blog-placeholder-2.jpg'
+color: 'yellow'
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vitae ultricies leo integer malesuada nunc vel risus commodo viverra. Adipiscing enim eu turpis egestas pretium. Euismod elementum nisi quis eleifend quam adipiscing. In hac habitasse platea dictumst vestibulum. Sagittis purus sit amet volutpat. Netus et malesuada fames ac turpis egestas. Eget magna fermentum iaculis eu non diam phasellus vestibulum lorem. Varius sit amet mattis vulputate enim. Habitasse platea dictumst quisque sagittis. Integer quis auctor elit sed vulputate mi. Dictumst quisque sagittis purus sit amet.

--- a/src/content/blog/using-mdx.mdx
+++ b/src/content/blog/using-mdx.mdx
@@ -3,6 +3,7 @@ title: 'Using MDX'
 description: 'Lorem ipsum dolor sit amet'
 pubDate: 'Jun 01 2024'
 heroImage: '../../assets/blog-placeholder-5.jpg'
+color: 'blue'
 ---
 
 This theme comes with the [@astrojs/mdx](https://docs.astro.build/en/guides/integrations-guide/mdx/) integration installed and configured in your `astro.config.mjs` config file. If you prefer not to use MDX, you can disable support by removing the integration from your config file.

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -9,7 +9,14 @@ import ScrollTopButton from "../components/ScrollTopButton.astro";
 
 type Props = CollectionEntry<"blog">["data"];
 
-const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
+const {
+  title,
+  description,
+  pubDate,
+  updatedDate,
+  heroImage,
+  color = 'red',
+} = Astro.props;
 ---
 
 <html lang="en">
@@ -150,7 +157,7 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
   </head>
 </html>
 
-<body class="page-blog">
+<body class={"page-blog page-" + color}>
   <Header />
   <main>
     <div class="corner-decoration top-left"></div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -5,7 +5,7 @@ import Layout from '../layouts/BaseLayout.astro';
 <Layout
         title="About Me"
         description="Who is he?"
-        pageClass="page-about"
+        pageClass="page-yellow"
 >
   <h1>Who is Arttu?</h1>
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -72,13 +72,13 @@ const posts = (await getCollection("blog")).sort(
         font-size: 24px;
         font-weight: 600;
         font-family: var(--font-heading);
-        color: var(--color-text);
+        color: var(--accent);
         line-height: 1.2;
       }
 
       .date {
         font-size: 14px;
-        color: var(--color-gray);
+        color: var(--accent);
         margin: 0;
       }
 
@@ -105,6 +105,18 @@ const posts = (await getCollection("blog")).sort(
         color: var(--accent);
       }
 
+      .post-red {
+        --accent: var(--accent-red);
+      }
+
+      .post-blue {
+        --accent: var(--accent-blue);
+      }
+
+      .post-yellow {
+        --accent: var(--accent-yellow);
+      }
+
       @media (max-width: 720px) {
         ul {
           gap: 32px;
@@ -123,7 +135,7 @@ const posts = (await getCollection("blog")).sort(
     </style>
   </head>
 </html>
-<body class="page-blog">
+<body class="page-blog page-red">
   <Header />
   <main>
     <div class="corner-decoration top-left"></div>
@@ -132,7 +144,7 @@ const posts = (await getCollection("blog")).sort(
       <ul>
         {
           posts.map((post) => (
-            <li>
+            <li class={`post-${post.data.color}`}>
               <a href={`/blog/${post.id}/`}>
                 {post.data.heroImage && (
                   <Image

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -6,6 +6,7 @@ import Layout from '../layouts/BaseLayout.astro';
         page="experience"
         title="Experience"
         description="Lorem ipsum dolor sit amet"
+        pageClass="page-blue"
 >
 
   <h1>📈 Work</h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,7 @@
 import Layout from "../layouts/BaseLayout.astro";
 ---
 
-<Layout pageClass="page-home">
+<Layout pageClass="page-red">
   <h1>Hello, I'm Arttu</h1>
 
   <p>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -2,7 +2,7 @@
 import Layout from "../layouts/BaseLayout.astro";
 ---
 
-<Layout page="projects" title="Projects" description="Lorem ipsum dolor sit amet">
+<Layout page="projects" title="Projects" description="Lorem ipsum dolor sit amet" pageClass="page-yellow">
   <h1>🧪 Selected Projects</h1>
 
   <section>

--- a/src/pages/questbook.astro
+++ b/src/pages/questbook.astro
@@ -2,7 +2,7 @@
 import Layout from "../layouts/BaseLayout.astro";
 ---
 
-<Layout page="questbook" title="Skills" description="Lorem ipsum dolor sit amet">
+<Layout page="questbook" title="Skills" description="Lorem ipsum dolor sit amet" pageClass="page-blue">
   <h1>🗡️ Questbook</h1>
   <p>
     Greetings, traveler. A quest lies before you: visit every page in this

--- a/src/pages/skills.astro
+++ b/src/pages/skills.astro
@@ -2,7 +2,7 @@
 import Layout from "../layouts/BaseLayout.astro";
 ---
 
-<Layout title="Skills" description="Lorem ipsum dolor sit amet" pageClass="page-skills">
+<Layout title="Skills" description="Lorem ipsum dolor sit amet" pageClass="page-red">
 
   <h1>🛠️ Skills</h1>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -55,6 +55,22 @@
 .page-about .bottom-left {
   --corner-color: var(--accent-skills);
 }
+
+/* Generic page color classes */
+.page-red {
+  --accent: var(--accent-red);
+  --corner-color: var(--accent-red);
+}
+
+.page-blue {
+  --accent: var(--accent-blue);
+  --corner-color: var(--accent-blue);
+}
+
+.page-yellow {
+  --accent: var(--accent-yellow);
+  --corner-color: var(--accent-yellow);
+}
 body {
   font-family: "Inter", sans-serif;
   margin: 0;


### PR DESCRIPTION
## Summary
- add generic color classes for red, blue, yellow pages
- cycle page colors for navigation pages
- assign color to blog posts and display them in blog index
- support color class in BlogPost layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68507a7d23e48329ae9a3d3625b5d1a7