### PR TITLE
Fix blog post color cycle and border styling

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -40,12 +40,13 @@ const today = new Date();
 	</div>
 </footer>
 <style>
-	footer {
-		padding: 2em 1em 6em 1em;
-		background: linear-gradient(var(--gray-gradient)) no-repeat;
-		color: rgb(var(--gray));
-		text-align: center;
-	}
+        footer {
+                padding: 2em 1em 6em 1em;
+                background: linear-gradient(var(--gray-gradient)) no-repeat;
+                color: rgb(var(--gray));
+                text-align: center;
+                border-top: 1px solid var(--corner-color);
+        }
 	.social-links {
 		display: flex;
 		justify-content: center;

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -71,7 +71,7 @@ import { SITE_TITLE } from "../consts";
     align-items: center;
     max-width: var(--max-width);
     margin: 0 auto;
-    border-bottom: 1px solid var(--color-gray);
+    border-bottom: 1px solid var(--corner-color);
   }
 
   .site-title {

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -4,11 +4,14 @@ import BlogPost from '../../layouts/BlogPost.astro';
 import { render } from 'astro:content';
 
 export async function getStaticPaths() {
-	const posts = await getCollection('blog');
-	return posts.map((post) => ({
-		params: { slug: post.id },
-		props: post,
-	}));
+        const posts = (await getCollection('blog')).sort(
+                (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+        );
+        const colors = ['blue', 'red', 'yellow'];
+        return posts.map((post, idx) => ({
+                params: { slug: post.id },
+                props: { ...post, color: colors[idx % colors.length] },
+        }));
 }
 type Props = CollectionEntry<'blog'>;
 
@@ -16,6 +19,6 @@ const post = Astro.props;
 const { Content } = await render(post);
 ---
 
-<BlogPost {...post.data}>
-	<Content />
+<BlogPost {...post.data} color={post.color}>
+        <Content />
 </BlogPost>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -11,6 +11,7 @@ import ScrollTopButton from "../../components/ScrollTopButton.astro";
 const posts = (await getCollection("blog")).sort(
   (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
 );
+const postColors = ["blue", "red", "yellow"];
 ---
 
 <!doctype html>
@@ -143,8 +144,8 @@ const posts = (await getCollection("blog")).sort(
     <section>
       <ul>
         {
-          posts.map((post) => (
-            <li class={`post-${post.data.color}`}>
+          posts.map((post, idx) => (
+            <li class={`post-${postColors[idx % postColors.length]}`}>
               <a href={`/blog/${post.id}/`}>
                 {post.data.heroImage && (
                   <Image


### PR DESCRIPTION
## Summary
- cycle blog card colors blue/red/yellow on index page
- ensure blog post pages receive the same color sequence
- match header bottom and footer top borders with the corner color

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850894d1ad48329bc6f4a6911e9dd8d