### PR TITLE
Refactor experience and projects into reusable components

### DIFF
--- a/src/components/ExperienceItem.astro
+++ b/src/components/ExperienceItem.astro
@@ -1,0 +1,19 @@
+---
+interface Props {
+  title: string;
+  timeframe?: string;
+}
+const { title, timeframe } = Astro.props;
+---
+
+<section class="experience-item">
+  <h3>{title}</h3>
+  {timeframe && <p><strong>{timeframe}</strong></p>}
+  <slot />
+</section>
+
+<style>
+  .experience-item {
+    margin-block: 2rem;
+  }
+</style>

--- a/src/components/ProjectItem.astro
+++ b/src/components/ProjectItem.astro
@@ -1,0 +1,17 @@
+---
+interface Props {
+  title: string;
+}
+const { title } = Astro.props;
+---
+
+<section class="project-item">
+  <h2>{title}</h2>
+  <slot />
+</section>
+
+<style>
+  .project-item {
+    margin-block: 2rem;
+  }
+</style>

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "../layouts/BaseLayout.astro";
+import ExperienceItem from "../components/ExperienceItem.astro";
 ---
 
 <Layout
@@ -11,9 +12,7 @@ import Layout from "../layouts/BaseLayout.astro";
 
   <h2>📈 Work</h2>
 
-  <section>
-    <h3>Developer @ Woolman</h3>
-    <p><strong>March 2024 – Present</strong></p>
+  <ExperienceItem title="Developer @ Woolman" timeframe="March 2024 – Present">
     <ul>
       <li>
         Built custom Shopify themes with Liquid, HTML, CSS, JS, and React.
@@ -34,13 +33,11 @@ import Layout from "../layouts/BaseLayout.astro";
       <strong>Tools:</strong> VSCode, Git, Teams, Slack, Jira, Teamwork, ChatGPT,
       Cursor, Copilot
     </p>
-  </section>
+  </ExperienceItem>
 
   <hr />
 
-  <section>
-    <h3>Junior Developer @ Woolman</h3>
-    <p><strong>September 2023 – March 2024</strong></p>
+  <ExperienceItem title="Junior Developer @ Woolman" timeframe="September 2023 – March 2024">
     <ul>
       <li>Joined via Saranen Developer Academy after B.Sc. graduation.</li>
       <li>Started hands-on with Liquid, JS, HTML, and CSS from day one.</li>
@@ -53,15 +50,16 @@ import Layout from "../layouts/BaseLayout.astro";
     </ul>
     <p><strong>Tech stack:</strong> Liquid, HTML, CSS, JS</p>
     <p><strong>Tools:</strong> Teams, Slack, Jira, Teamwork</p>
-  </section>
+  </ExperienceItem>
 
   <hr />
 
   <h2>🎓 Education</h2>
 
-  <section>
-    <h3>B.Sc. in Mathematical Information Technology</h3>
-    <p><strong>University of Jyväskylä — September 2016 - June 2023</strong></p>
+  <ExperienceItem
+    title="B.Sc. in Mathematical Information Technology"
+    timeframe="University of Jyväskylä — September 2016 - June 2023"
+  >
     <ul>
       <li><strong>Major:</strong> Computer Science</li>
       <li><strong>Minor:</strong> Psychology</li>
@@ -72,5 +70,5 @@ import Layout from "../layouts/BaseLayout.astro";
         >
       </li>
     </ul>
-  </section>
+  </ExperienceItem>
 </Layout>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "../layouts/BaseLayout.astro";
+import ProjectItem from "../components/ProjectItem.astro";
 ---
 
 <Layout
@@ -9,8 +10,7 @@ import Layout from "../layouts/BaseLayout.astro";
 >
   <h1>Projects</h1>
 
-  <section>
-    <h2>Consent Analyser</h2>
+  <ProjectItem title="Consent Analyser">
     <p>
       Chrome extension that checks if a CMP is correctly linked to Shopify's
       Customer Privacy API and inspects dataLayer pushes for analytics
@@ -18,12 +18,11 @@ import Layout from "../layouts/BaseLayout.astro";
     </p>
     <p>Not publicly available — email me if you'd like a demo.</p>
     <p><strong>Tech stack:</strong> JavaScript, HTML, CSS</p>
-  </section>
+  </ProjectItem>
 
   <hr />
 
-  <section>
-    <h2>Kandi Rush Saga</h2>
+  <ProjectItem title="Kandi Rush Saga">
     <p>
       A very serious browser game: earn 180 student credits before you run out
       of allowance months. Watch out for Plagiointisyytös and unexpected Moodle
@@ -38,15 +37,14 @@ import Layout from "../layouts/BaseLayout.astro";
       <a href="https://github.com/succabs/kandi-rush-saga">GitHub</a>
     </p>
     <p><strong>Tech stack:</strong> JavaScript, Phaser</p>
-  </section>
+  </ProjectItem>
 
   <hr />
 
-  <section>
-    <h2>Pitmaster</h2>
+  <ProjectItem title="Pitmaster">
     <p>Gladiator manager web game inspired by Areena 5 and Travian.</p>
     <p>
       <strong>Tech stack:</strong> Svelte, TailwindCSS, ExpressJS, PostgreSQL, VPS
     </p>
-  </section>
+  </ProjectItem>
 </Layout>


### PR DESCRIPTION
## Summary
- add `ExperienceItem` and `ProjectItem` Astro components
- refactor experience page to use `ExperienceItem`
- refactor projects page to use `ProjectItem`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68529bc9946c8329b643521aa87abcd5