### PR TITLE
Add blog tags, filtering and pagination

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -15,6 +15,7 @@ const blog = defineCollection({
 
       updatedDate: z.coerce.date().optional(),
       heroImage: image().optional(),
+      tags: z.array(z.string()).optional(),
       color: z.enum(["red", "blue", "yellow"]).optional(),
     }),
 });

--- a/src/content/blog/my-top-three-favourite-tech-series-of-all-time.md
+++ b/src/content/blog/my-top-three-favourite-tech-series-of-all-time.md
@@ -4,7 +4,7 @@ description: "An exploration of three standout tech series that offer drama, hum
 pubDate: 2025-01-23
 heroImage: "../../assets/tech-series.jpg"
 author: "Arttu Nikkilä"
-tags: ["hobbies, tv"]
+tags: ["hobbies", "tv"]
 excerpt: "I'm a huge fan of good TV series and technology. Come find out what my favourites are."
 ---
 

--- a/src/content/blog/the-perfect-mouse-and-keyboard.mdx
+++ b/src/content/blog/the-perfect-mouse-and-keyboard.mdx
@@ -4,7 +4,7 @@ description: "The keyboard and mouse upgrade that finally solved my multi-comput
 pubDate: 2025-06-18
 heroImage: "../../assets/keyboard-and-mouse.jpg"
 author: "Arttu Nikkilä"
-tags: ["tech, workflow"]
+tags: ["tech", "workflow"]
 excerpt: "The keyboard and mouse upgrade that finally solved my multi-computer chaos. Not paid to write this."
 ---
 

--- a/src/content/blog/top-10-reasons-why-i-stopped-grinding-duolingo.md
+++ b/src/content/blog/top-10-reasons-why-i-stopped-grinding-duolingo.md
@@ -5,7 +5,7 @@ description: "I used Duolingo daily for 628 days to learn Norwegian. Eventually,
 author: "Arttu Nikkilä"
 excerpt: "I stopped using Duolingo after 628 days. Here's why it no longer helped me learn Norwegian - or fit into my life anymore."
 pubDate: 2025-06-26
-tags: ["learning, personal"]
+tags: ["learning", "personal"]
 ---
 
 After a 628-day streak, I finally quit Duolingo - it just wasn’t working for me anymore. If you've read my earlier post about spending a full year learning Norwegian on the app ([365 Days of Learning Norwegian on Duolingo](https://arttu.net/blog/365-days-of-learning-norwegian-on-duolingo/)), this might come as a surprise. But after nearly two years of daily practice, I reached a point where continuing no longer made sense. Here's why.

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -7,13 +7,22 @@ import FormattedDate from "../components/FormattedDate.astro";
 import { Image } from "astro:assets";
 import ScrollTopButton from "../components/ScrollTopButton.astro";
 
-type Props = CollectionEntry<"blog">["data"] & {
-  readTime: number;
-  color: "red" | "blue";
+type Props = CollectionEntry<"blog">["data"] & { 
+  readTime: number; 
+  color: "red" | "blue"; 
+  tags?: string[]; 
 };
 
-const { title, description, pubDate, updatedDate, heroImage, color, readTime } =
-  Astro.props as Props;
+const {
+  title,
+  description,
+  pubDate,
+  updatedDate,
+  heroImage,
+  color,
+  readTime,
+  tags = [],
+} = Astro.props as Props;
 ---
 
 <html lang="en">
@@ -80,6 +89,22 @@ const { title, description, pubDate, updatedDate, heroImage, color, readTime } =
         font-style: italic;
         font-size: 13px;
         color: var(--color-text);
+      }
+
+      .tag-list {
+        margin-top: 1rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+
+      .tag-badge {
+        font-family: var(--font-heading);
+        text-transform: uppercase;
+        font-size: 0.75rem;
+        padding: 0.25em 0.5em;
+        border: 2px solid var(--accent);
+        color: var(--accent);
       }
 
       p {
@@ -195,9 +220,16 @@ const { title, description, pubDate, updatedDate, heroImage, color, readTime } =
                 </div>
               )
             }
-            <span class="read-time"> • {readTime} min read</span>
+            <span class="read-time"> 🕒 {readTime} min read</span>
           </div>
           <h1>{title}</h1>
+          {tags.length > 0 && (
+            <div class="tag-list">
+              {tags.map((t) => (
+                <span class="tag-badge" key={t}>{t}</span>
+              ))}
+            </div>
+          )}
           <hr />
         </div>
         <slot />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -25,6 +25,9 @@ const posts = (await getCollection("blog"))
   });
 
 const postColors = ["blue", "red"];
+const allTags = Array.from(
+  new Set(posts.flatMap((p) => p.data.tags ?? []))
+).sort();
 ---
 
 <!doctype html>
@@ -145,6 +148,15 @@ const postColors = ["blue", "red"];
           align-items: flex-start;
         }
 
+        .post-item {
+          flex-direction: column;
+        }
+
+        .post-image {
+          width: 100%;
+          max-width: none;
+        }
+
         ul li:first-child .title {
           font-size: 32px;
         }
@@ -160,6 +172,41 @@ const postColors = ["blue", "red"];
       .post-item {
         padding-bottom: 2rem;
         border-bottom: 1px solid var(--accent);
+        display: flex;
+        gap: 2rem;
+        align-items: flex-start;
+      }
+
+      .post-content {
+        flex: 1;
+      }
+
+      .post-image {
+        width: 40%;
+        max-width: 300px;
+      }
+
+      .post-image img {
+        width: 100%;
+        height: auto;
+        aspect-ratio: 16 / 9;
+        object-fit: cover;
+      }
+
+      .tag-list {
+        margin: 0.5rem 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+
+      .tag-badge {
+        font-family: var(--font-heading);
+        text-transform: uppercase;
+        font-size: 0.75rem;
+        padding: 0.25em 0.5em;
+        border: 2px solid var(--accent);
+        color: var(--accent);
       }
 
       .post-title {
@@ -206,6 +253,51 @@ const postColors = ["blue", "red"];
       .read-more:hover {
         color: var(--color-text);
       }
+
+      .filter-buttons {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-bottom: 2rem;
+      }
+
+      .filter-btn {
+        font-family: var(--font-heading);
+        text-transform: uppercase;
+        font-size: 0.75rem;
+        padding: 0.25em 0.5em;
+        border: 2px solid var(--color-text);
+        background: transparent;
+        color: var(--color-text);
+        cursor: pointer;
+      }
+
+      .filter-btn.active {
+        background: var(--color-text);
+        color: var(--color-bg);
+      }
+
+      .pagination {
+        margin-top: 2rem;
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+      }
+
+      .page-btn {
+        font-family: var(--font-heading);
+        font-size: 0.75rem;
+        padding: 0.25em 0.5em;
+        border: 2px solid var(--color-text);
+        background: transparent;
+        color: var(--color-text);
+        cursor: pointer;
+      }
+
+      .page-btn.active {
+        background: var(--color-text);
+        color: var(--color-bg);
+      }
     </style>
   </head>
 </html>
@@ -215,30 +307,57 @@ const postColors = ["blue", "red"];
     <div class="corner-decoration top-left"></div>
     <div class="corner-decoration top-right"></div>
     <h1>Blog index</h1>
+    <div class="filter-buttons">
+      <button class="filter-btn active" data-tag="all">All</button>
+      {allTags.map((tag) => (
+        <button class="filter-btn" data-tag={tag}>{tag}</button>
+      ))}
+    </div>
     <section class="posts-list">
       {
         posts.map((post, idx) => (
           <article
             class={`post-item post-${postColors[idx % postColors.length]}`}
+            data-tags={(post.data.tags ?? []).join(',')}
           >
-            <h2 class="post-title">
-              <a href={`/blog/${post.id}/`}>{post.data.title}</a>
-            </h2>
+            <div class="post-content">
+              <h2 class="post-title">
+                <a href={`/blog/${post.id}/`}>{post.data.title}</a>
+              </h2>
 
-            {post.data.excerpt && (
-              <p class="post-excerpt">{post.data.excerpt}</p>
+              {post.data.excerpt && (
+                <p class="post-excerpt">{post.data.excerpt}</p>
+              )}
+              {post.data.tags && post.data.tags.length > 0 && (
+                <div class="tag-list">
+                  {post.data.tags.map((t) => (
+                    <span class="tag-badge" key={t}>{t}</span>
+                  ))}
+                </div>
+              )}
+              <p class="post-date">
+                <FormattedDate date={post.data.pubDate} />
+                <span class="read-time"> 🕒 {post.data.readTime} min read</span>
+              </p>
+              <a href={`/blog/${post.id}/`} class="read-more">
+                Read More →
+              </a>
+            </div>
+            {post.data.heroImage && (
+              <div class="post-image">
+                <Image
+                  width={300}
+                  height={169}
+                  src={post.data.heroImage}
+                  alt=""
+                />
+              </div>
             )}
-            <p class="post-date">
-              <FormattedDate date={post.data.pubDate} />
-              <span class="read-time"> • {post.data.readTime} min read</span>
-            </p>
-            <a href={`/blog/${post.id}/`} class="read-more">
-              Read More →
-            </a>
           </article>
         ))
       }
     </section>
+    <div class="pagination"></div>
   </main>
   <div id="cookie-banner" class="cookie-banner">
     <div>
@@ -257,6 +376,53 @@ const postColors = ["blue", "red"];
 
   <script type="module">
     if (typeof window !== "undefined") {
+      const postsPerPage = 5;
+      const posts = Array.from(document.querySelectorAll('.post-item'));
+      const filterButtons = document.querySelectorAll('.filter-btn');
+      const pagination = document.querySelector('.pagination');
+      let currentTag = 'all';
+      let currentPage = 1;
+
+      filterButtons.forEach((btn) => {
+        btn.addEventListener('click', () => {
+          filterButtons.forEach((b) => b.classList.remove('active'));
+          btn.classList.add('active');
+          currentTag = btn.dataset.tag || 'all';
+          currentPage = 1;
+          update();
+        });
+      });
+
+      function update() {
+        const visible = posts.filter((p) => {
+          if (currentTag === 'all') return true;
+          const tags = p.dataset.tags ? p.dataset.tags.split(',') : [];
+          return tags.includes(currentTag);
+        });
+        const totalPages = Math.max(1, Math.ceil(visible.length / postsPerPage));
+        pagination.innerHTML = '';
+        for (let i = 1; i <= totalPages; i++) {
+          const b = document.createElement('button');
+          b.textContent = String(i);
+          b.className = 'page-btn' + (i === currentPage ? ' active' : '');
+          b.addEventListener('click', () => {
+            currentPage = i;
+            update();
+          });
+          pagination.appendChild(b);
+        }
+        posts.forEach((p) => (p.style.display = 'none'));
+        visible.forEach((p, idx) => {
+          const start = (currentPage - 1) * postsPerPage;
+          const end = start + postsPerPage;
+          if (idx >= start && idx < end) {
+            p.style.display = '';
+          }
+        });
+      }
+
+      update();
+
       const pageMap = {
         "/": "home",
         "/experience": "experience",


### PR DESCRIPTION
## Summary
- support tags in content schema and front matter
- display post tags and read time on blog posts
- show hero images and tags in blog index
- add filtering and pagination for blog index
- style badges and controls to match brandbook

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685d82b21cc8832988b694b284762ad7