### PR TITLE
Add alt text for blog hero images

### DIFF
--- a/src/components/BlogCard.astro
+++ b/src/components/BlogCard.astro
@@ -8,14 +8,15 @@ export interface Props {
   href: string;
   excerpt?: string;
   heroImage?: ImageMetadata;
+  heroImageAlt?: string;
 }
 
-const { title, date, href, excerpt, heroImage } = Astro.props as Props;
+const { title, date, href, excerpt, heroImage, heroImageAlt } = Astro.props as Props;
 ---
 <article class="blog-card">
   {heroImage && (
     <a href={href} class="image">
-      <Image src={heroImage} alt="" width={420} height={236} />
+      <Image src={heroImage} alt={heroImageAlt ?? title} width={420} height={236} />
     </a>
   )}
   <div class="content">

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -15,6 +15,7 @@ const blog = defineCollection({
 
       updatedDate: z.coerce.date().optional(),
       heroImage: image().optional(),
+      heroImageAlt: z.string().optional(),
       tags: z.array(z.string()).optional(),
       color: z.enum(["red", "blue"]).optional(),
     }),

--- a/src/content/blog/365-days-of-learning-norwegian-on-duolingo.md
+++ b/src/content/blog/365-days-of-learning-norwegian-on-duolingo.md
@@ -3,6 +3,7 @@ title: "What I Learned After 365 Days of Norwegian on Duolingo"
 description: "After a 365-day streak learning Norwegian (bokmål) on Duolingo, I share what worked, what didn’t, and whether the app can take you beyond the basics."
 pubDate: 2024-08-29
 heroImage: "../../assets/norway.jpg"
+heroImageAlt: "View of a Norwegian fjord"
 author: "Arttu Nikkilä"
 tags: ["learning", "personal"]
 excerpt: "A full year of daily Norwegian on Duolingo: 365 days of streaks, struggles, and shouting numbers at my phone while it refused to understand me. This isn’t just about learning a language; it’s about chasing dreams of fjords, Röyksopp, and maybe even a new life in Norway. Come for the insights, stay for the chaos."

--- a/src/content/blog/my-top-three-favourite-tech-series-of-all-time.md
+++ b/src/content/blog/my-top-three-favourite-tech-series-of-all-time.md
@@ -3,6 +3,7 @@ title: "Top 3 Tech Series Every Developer Should Watch"
 description: "Three essential tech series every developer should watch — drama, satire, and suspense from Halt and Catch Fire to Mr. Robot."
 pubDate: 2025-01-23
 heroImage: "../../assets/tech-series.jpg"
+heroImageAlt: "Logos from popular tech TV series"
 author: "Arttu Nikkilä"
 tags: ["hobbies", "personal"]
 excerpt: "I'm a huge fan of good TV series and technology. Here are my top 3 essential tech series every developer should watch — drama, satire, and suspense from Halt and Catch Fire to Mr. Robot."

--- a/src/content/blog/portfolio-redesign-bauhaus.md
+++ b/src/content/blog/portfolio-redesign-bauhaus.md
@@ -4,6 +4,7 @@ description: "How I redesigned my developer portfolio using Astro, Bauhaus desig
 pubDate: 2025-06-17
 tags: ["development"]
 heroImage: "../../assets/bauhaus.jpg"
+heroImageAlt: "Bauhaus-inspired geometric design"
 excerpt: "A breakdown of how I redesigned my portfolio site from a retro mess into a clean, Bauhaus-inspired digital home with the help of GenAI tools."
 ---
 

--- a/src/content/blog/the-perfect-mouse-and-keyboard.mdx
+++ b/src/content/blog/the-perfect-mouse-and-keyboard.mdx
@@ -3,6 +3,7 @@ title: "How I Made My Life Easier: I Bought the Logitech MX Keys Mini and Master
 description: "The keyboard and mouse upgrade that solved my multi-device setup — Logitech MX Keys Mini and Master 3S in daily use."
 pubDate: 2025-06-18
 heroImage: "../../assets/keyboard-and-mouse.jpg"
+heroImageAlt: "Logitech MX Keys Mini keyboard and MX Master 3S mouse"
 author: "Arttu Nikkilä"
 tags: ["tech", "development"]
 excerpt: "The keyboard and mouse upgrade that solved my multi-device setup — Logitech MX Keys Mini and Master 3S in daily use. No more chaos, no more pain."

--- a/src/content/blog/top-10-reasons-why-i-stopped-grinding-duolingo.md
+++ b/src/content/blog/top-10-reasons-why-i-stopped-grinding-duolingo.md
@@ -1,6 +1,7 @@
 ---
 title: "10 Reasons I Stopped Using Duolingo in 2025 After Nearly 2 Years"
 heroImage: "../../assets/duolingo.jpg"
+heroImageAlt: "Duolingo owl mascot"
 description: "I used Duolingo daily for 628 days to learn Norwegian. Eventually, it stopped working for me. Here are 10 reasons why I quit — from AI-generated content to gamification burnout."
 author: "Arttu Nikkilä"
 excerpt: "I used Duolingo daily for 628 days to learn Norwegian. Eventually, it stopped working for me. Here are 10 reasons why I quit — from AI-generated content to gamification burnout."

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -19,6 +19,7 @@ const {
   pubDate,
   updatedDate,
   heroImage,
+  heroImageAlt,
   color,
   readTime,
   tags = [],
@@ -230,7 +231,12 @@ const structuredData = {
       <div class="hero-image">
         {
           heroImage && (
-            <Image width={1020} height={510} src={heroImage} alt="" />
+            <Image
+              width={1020}
+              height={510}
+              src={heroImage}
+              alt={heroImageAlt ?? title}
+            />
           )
         }
       </div>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -384,7 +384,7 @@ const allTags = Array.from(
                   width={300}
                   height={169}
                   src={post.data.heroImage}
-                  alt=""
+                  alt={post.data.heroImageAlt ?? post.data.title}
                 />
               </div>
             )}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -158,6 +158,7 @@ const structuredData = {
             excerpt={post.data.excerpt}
             href={`/blog/${post.id}/`}
             heroImage={post.data.heroImage}
+            heroImageAlt={post.data.heroImageAlt}
           />
         ))
       }

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -95,7 +95,7 @@ const bg = "#faf8f4"; // sama kuin --color-bg
 <div id="image-modal" class="image-modal">
   <div class="modal-backdrop"></div>
   <span class="modal-close">&times;</span>
-  <img class="modal-content" id="modal-image" />
+  <img class="modal-content" id="modal-image" alt="Expanded project image" />
 </div>
 
 <script>


### PR DESCRIPTION
## Summary
- include heroImageAlt in content schema
- add alt descriptions for hero images in blog posts
- pass alt text through BlogCard, BlogPost, and blog index
- add missing alt on modal image

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e908058e08329b3944821c0229ffe