### PR TITLE
fix: use Astro Image for project thumbnails

### DIFF
--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,8 +1,12 @@
 ---
 import Layout from "../layouts/BaseLayout.astro";
 import { Image } from "astro:assets";
+import type { ImageMetadata } from "astro";
 
-import juoksulokiImage from "../juoksuloki_screenshot.png";
+import consentImage from "../assets/consent_analyser_screenshot.png";
+import juoksulokiImage from "../assets/juoksuloki_screenshot.png";
+import kandirushsagaImage from "../assets/kandirushsaga_screenshot.png";
+import pitmasterImage from "../assets/pitmaster_screenshot.png";
 
 // ✅ TS is OK in frontmatter
 interface Link {
@@ -16,8 +20,8 @@ interface Project {
   desc: string[];
   tech: string[];
   links?: Link[];
-  images: string[];
-  thumb?: string;
+  images: ImageMetadata[];
+  thumb?: ImageMetadata;
 }
 
 const projects: Project[] = [
@@ -31,7 +35,7 @@ const projects: Project[] = [
       "No public code available (work project). Email for a demo :)",
     ],
     tech: ["JavaScript", "HTML", "CSS"],
-    images: [{ juoksulokiImage.src }],
+    images: [consentImage],
   },
   {
     id: "juoksuloki",
@@ -42,7 +46,7 @@ const projects: Project[] = [
       "Niche tool built for Suunto app on iPhone + Mac users who prefer local run data management and advanced analysis.",
     ],
     tech: ["Python", "Pandas", "Excel"],
-    images: ["./juoksuloki_screenshot.png"],
+    images: [juoksulokiImage],
   },
   {
     id: "kandi",
@@ -57,7 +61,7 @@ const projects: Project[] = [
       { label: "Code", href: "https://github.com/succabs/kandirushsaga" },
       { label: "Live", href: "https://arttu.net/kandirushsaga" },
     ],
-    images: ["/kandirushsaga_screenshot.png"],
+    images: [kandirushsagaImage],
   },
   {
     id: "pitmaster",
@@ -68,10 +72,15 @@ const projects: Project[] = [
       "Front-end ready; back-end and graphics WIP.",
     ],
     tech: ["Svelte", "TailwindCSS", "ExpressJS", "PostgreSQL", "VPS"],
-    images: ["/pitmaster_screenshot.png"],
+    images: [pitmasterImage],
   },
 ];
 
+const projectsData = projects.map((p) => ({
+  ...p,
+  images: p.images.map((img) => img.src),
+  thumb: p.thumb?.src,
+}));
 const mysteryCount = 2;
 ---
 
@@ -103,7 +112,7 @@ const mysteryCount = 2;
             data-index={i}
           >
             <div class="tile-frame">
-              <img src={p.thumb ?? p.images[0]} alt="" loading="lazy" />
+              <Image src={p.thumb ?? p.images[0]} alt="" />
               <span class="codename">{p.codename}</span>
               <span class="stamp" aria-hidden="true">
                 SELECTED
@@ -172,7 +181,7 @@ const mysteryCount = 2;
     id="projects-data"
     hidden
     aria-hidden="true"
-    set:html={JSON.stringify(projects)}
+    set:html={JSON.stringify(projectsData)}
   />
 </Layout>
 
@@ -355,7 +364,7 @@ const mysteryCount = 2;
   }
 
   // Preselect first card
-  if (DATA.length) selectByIndex(0);
+  if (DATA.length && !isNarrow()) selectByIndex(0);
 </script>
 
 <style>
@@ -399,7 +408,7 @@ const mysteryCount = 2;
     box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
   }
 
-  .tile-frame img {
+  .tile-frame :global(img) {
     position: absolute;
     inset: 0;
     width: 100%;
@@ -433,7 +442,7 @@ const mysteryCount = 2;
       0 0 18px 4px rgba(255, 68, 68, 0.55);
     filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.25));
   }
-  .select-tile:hover img {
+  .select-tile:hover :global(img) {
     transform: scale(1.05);
     filter: saturate(1.05) contrast(1.05);
   }


### PR DESCRIPTION
## Summary
- use Astro's `<Image>` component for project thumbnails and import images from assets
- prevent auto-scrolling to first project on mobile

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c530b49c5c8329adb7053cf3a564dc